### PR TITLE
fix: issue triage agent not applying labels

### DIFF
--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -35,6 +35,7 @@ Your goal is to keep the issue tracker organized, actionable, and free of duplic
 When an issue is opened or edited:
 
 1. **Classify the issue type** — apply exactly one type label using `update-issue`.
+   When calling `update-issue`, you MUST include the issue's current title in the `title` field alongside `labels`. For example: `update_issue(title: "the issue title", labels: ["enhancement"])`. This is required for the output to be accepted.
    Only use labels that already exist in the repository. Use `get_label` to verify a label exists before applying it.
    Common labels to check for: `bug`, `enhancement`, `question`, `documentation`.
    - `bug` — something is broken or behaving incorrectly


### PR DESCRIPTION
## Problem

The Issue Triage Agent was running successfully but labels were never applied to issues (see #21, #19).

**Root cause (from logs):**
1. The Copilot CLI was launched without `--no-ask-user`, blocking MCP servers in CI (fixed by recompiling with gh-aw v0.68.3)
2. The agent called `update_issue(labels: ["enhancement"])` but gh-aw's safe output validator requires at least one of `status`, `title`, or `body` — so the output was silently discarded and labels never applied

## Fix

- **Recompiled** lock file with gh-aw v0.68.3 (adds `--no-ask-user` flag)
- **Updated prompt** to instruct the agent to always include the issue `title` when calling `update_issue`, so the safe output validation passes
- **Added `workflow_dispatch`** trigger for manual testing

## Changes
- `.github/workflows/issue-triage.md` — prompt fix + workflow_dispatch trigger
- `.github/workflows/issue-triage.lock.yml` — recompiled with v0.68.3

Fixes #21